### PR TITLE
Add move_mouse helper for Basic Craft

### DIFF
--- a/global_functions.py
+++ b/global_functions.py
@@ -14,6 +14,12 @@ button_menu_color = "#0d1623"  # Couleur d'arrière-plan des boutons dans le men
 currency_used = 0
 
 
+def move_mouse(app, x, y):
+    """Move the mouse according to global settings."""
+    duration = app.mouse_move_time_var.get() if app.disable_mouse_teleport_var.get() else 0
+    pyautogui.moveTo(x, y, duration=duration)
+
+
 def safe_copy(old_copy: str) -> str:
     for _ in range(7):
         pyautogui.hotkey('ctrl', 'c')

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from global_functions import (
     safe_copy,
     extract_socket_colors,
     extract_link_count,
+    move_mouse,
 )
 
 from tabs import general, currency, no_mod_craft, basic_craft, beast_module, divination_card
@@ -837,7 +838,7 @@ class App:
                 messagebox.showinfo("Info", "craft finis")
                 break
             pyautogui.rightClick()
-            pyautogui.moveTo(item_x, item_y, duration=self.mouse_move_time_var.get())
+            move_mouse(self, item_x, item_y)
             pyautogui.click()
             time.sleep(self.craft_delay_var.get())
 
@@ -886,7 +887,7 @@ class App:
                 print("Alteration check failed, stopping craft")
                 break
             pyautogui.rightClick()
-            pyautogui.moveTo(item_x, item_y, duration=self.mouse_move_time_var.get())
+            move_mouse(self, item_x, item_y)
             pyautogui.click()
             print(f"Applied Alteration at step {i+1}")
             time.sleep(self.craft_delay_var.get())
@@ -898,7 +899,7 @@ class App:
                     print("Augment check failed, stopping craft")
                     break
                 pyautogui.rightClick()
-                pyautogui.moveTo(item_x, item_y, duration=self.mouse_move_time_var.get())
+                move_mouse(self, item_x, item_y)
                 pyautogui.click()
                 print(f"Applied Augment at step {i+1}")
                 time.sleep(self.craft_delay_var.get())

--- a/tabs/basic_craft.py
+++ b/tabs/basic_craft.py
@@ -4,7 +4,13 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import pyautogui
 import pyperclip
-from global_functions import background_color, text_color, button_color, extract_socket_colors
+from global_functions import (
+    background_color,
+    text_color,
+    button_color,
+    extract_socket_colors,
+    move_mouse,
+)
 
 
 def create_basic_craft(app):
@@ -114,7 +120,7 @@ def run_basic_craft(app):
             messagebox.showinfo("Info", "craft finis")
             break
         pyautogui.rightClick()
-        pyautogui.moveTo(item_x, item_y, duration=app.mouse_move_time_var.get())
+        move_mouse(app, item_x, item_y)
         pyautogui.click()
         time.sleep(app.craft_delay_var.get())
 
@@ -124,7 +130,7 @@ def run_basic_craft(app):
                 messagebox.showinfo("Info", "craft finis")
                 break
             pyautogui.rightClick()
-            pyautogui.moveTo(item_x, item_y, duration=app.mouse_move_time_var.get())
+            move_mouse(app, item_x, item_y)
             pyautogui.click()
             time.sleep(app.craft_delay_var.get())
 


### PR DESCRIPTION
## Summary
- add `move_mouse` utility to centralize mouse movement behavior
- use `move_mouse` in Basic Craft tab
- replace direct pyautogui calls with `move_mouse` in basic craft methods

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68656c031d8483228185f0b283dfa658