### PR TITLE
Add move_and_click helper

### DIFF
--- a/global_functions.py
+++ b/global_functions.py
@@ -18,6 +18,19 @@ def move_mouse(app, x, y):
     """Move the mouse according to global settings."""
     duration = app.mouse_move_time_var.get() if app.disable_mouse_teleport_var.get() else 0
     pyautogui.moveTo(x, y, duration=duration)
+    if app.random_delay_var.get():
+        time.sleep(random.uniform(0.17, 0.25))
+
+
+def move_and_click(app, x, y, button="left"):
+    """Move the mouse then perform a click using the given button."""
+    move_mouse(app, x, y)
+    if button == "right":
+        pyautogui.rightClick()
+    else:
+        pyautogui.click()
+    if app.random_delay_var.get():
+        time.sleep(random.uniform(0.17, 0.25))
 
 
 def safe_copy(old_copy: str) -> str:

--- a/tabs/basic_craft.py
+++ b/tabs/basic_craft.py
@@ -10,7 +10,7 @@ from global_functions import (
     text_color,
     button_color,
     extract_socket_colors,
-    move_mouse,
+    move_and_click,
 )
 
 
@@ -136,8 +136,7 @@ def run_basic_craft(app):
             messagebox.showinfo("Info", "craft finis")
             break
         pyautogui.rightClick()
-        move_mouse(app, item_x, item_y)
-        pyautogui.click()
+        move_and_click(app, item_x, item_y)
         time.sleep(app.craft_delay_var.get())
 
         if app.check_vars["Use Aug?"].get():
@@ -190,8 +189,7 @@ def run_basic_craft_test(app):
             print("Alteration check failed, stopping craft")
             break
         pyautogui.rightClick()
-        move_mouse(app, item_x, item_y)
-        pyautogui.click()
+        move_and_click(app, item_x, item_y)
         print(f"Applied Alteration at step {i+1}")
         time.sleep(app.craft_delay_var.get())
 
@@ -202,8 +200,7 @@ def run_basic_craft_test(app):
                 print("Augment check failed, stopping craft")
                 break
             pyautogui.rightClick()
-            move_mouse(app, item_x, item_y)
-            pyautogui.click()
+            move_and_click(app, item_x, item_y)
             print(f"Applied Augment at step {i+1}")
             time.sleep(app.craft_delay_var.get())
 


### PR DESCRIPTION
## Summary
- support random delay in `move_mouse`
- add `move_and_click` helper for moving then clicking
- update `basic_craft` module to use the helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686574f1f7c883229892b43e5f99f5b7