### PR TITLE
Remove unused wrapper method

### DIFF
--- a/main.py
+++ b/main.py
@@ -241,7 +241,7 @@ class App:
             first_point = self.chain_beast_points[0]
             x, y = first_point['x'], first_point['y']
             # Appeler la fonction check avec les coordonnées et le texte 'beast'
-            self.check(x, y, "beast")
+            check(x, y, "beast")
         else:
             print("Aucune position de Beast disponible.")
 
@@ -261,7 +261,7 @@ class App:
         # Parcourir toutes les positions et utiliser la fonction check
         for point in self.chain_beast_points:
             x, y = point['x'], point['y']
-            is_bestiary_orb, copied_text = self.check(x, y, "Bestiary Orb")
+            is_bestiary_orb, copied_text = check(x, y, "Bestiary Orb")
 
             if is_bestiary_orb:
                 # Rechercher le stack size dans le texte
@@ -297,7 +297,7 @@ class App:
             x, y = point['x'], point['y']
 
             # Vérifier la position actuelle par rapport à la précédente
-            is_empty, copied_text = self.check(x, y, previous_text)
+            is_empty, copied_text = check(x, y, previous_text)
 
             if is_empty:
                 empty_positions.append(index)
@@ -370,7 +370,7 @@ class App:
                     first_x, first_y = first_point['x'], first_point['y']
 
                     # Appeler la méthode check sur la position actuelle
-                    is_orb_found, copied_text = self.check(first_x, first_y, "Bestiary Orb")
+                    is_orb_found, copied_text = check(first_x, first_y, "Bestiary Orb")
 
                     if is_orb_found:
                         # Utiliser une regex pour trouver "Stack Size: X/10"
@@ -441,9 +441,6 @@ class App:
 
 
 
-    def check(self, x, y, text):
-        """Wrapper autour de la fonction globale check."""
-        return check(x, y, text)
 
 
 

--- a/tabs/basic_craft.py
+++ b/tabs/basic_craft.py
@@ -11,6 +11,7 @@ from global_functions import (
     button_color,
     extract_socket_colors,
     move_mouse,
+    check,
 )
 
 
@@ -126,12 +127,12 @@ def run_basic_craft(app):
         aug_x, aug_y = map(int, augment_pos.split(';'))
 
     while True:
-        _, item_text = app.check(item_x, item_y, "")
+        _, item_text = check(item_x, item_y, "")
         if regex.search(item_text) or pattern_lower in item_text.lower():
             messagebox.showinfo("Info", "craft finis")
             break
 
-        same, _ = app.check(alt_x, alt_y, item_text)
+        same, _ = check(alt_x, alt_y, item_text)
         if same:
             messagebox.showinfo("Info", "craft finis")
             break
@@ -141,7 +142,7 @@ def run_basic_craft(app):
         time.sleep(app.craft_delay_var.get())
 
         if app.check_vars["Use Aug?"].get():
-            same, _ = app.check(aug_x, aug_y, item_text)
+            same, _ = check(aug_x, aug_y, item_text)
             if same:
                 messagebox.showinfo("Info", "craft finis")
                 break
@@ -178,13 +179,13 @@ def run_basic_craft_test(app):
         aug_x, aug_y = map(int, augment_pos.split(';'))
 
     for i in range(10):
-        _, item_text = app.check(item_x, item_y, "")
+        _, item_text = check(item_x, item_y, "")
         print(f"Step {i+1}: item text -> {item_text}")
         if regex.search(item_text) or pattern_lower in item_text.lower():
             print("Regex found or contained, stopping craft")
             break
 
-        same, _ = app.check(alt_x, alt_y, item_text)
+        same, _ = check(alt_x, alt_y, item_text)
         print(f"Step {i+1}: alteration same -> {same}")
         if same:
             print("Alteration check failed, stopping craft")
@@ -196,7 +197,7 @@ def run_basic_craft_test(app):
         time.sleep(app.craft_delay_var.get())
 
         if app.check_vars["Use Aug?"].get():
-            same, _ = app.check(aug_x, aug_y, item_text)
+            same, _ = check(aug_x, aug_y, item_text)
             print(f"Step {i+1}: augment same -> {same}")
             if same:
                 print("Augment check failed, stopping craft")


### PR DESCRIPTION
## Summary
- replace remaining calls to removed `App.check` wrapper with direct `check` function
- import `check` in `basic_craft.py`

## Testing
- `python -m py_compile main.py`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'RePoE')*
- `python test2.py` *(fails: ModuleNotFoundError: No module named 'RePoE')*

------
https://chatgpt.com/codex/tasks/task_e_6865741f01508322ae880eb5a2940d6e