### PR TITLE
Add F12 global exit hotkey

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ import pygetwindow as gw
 
 import pyautogui
 import pyperclip
+import threading
+import keyboard
 
 from global_functions import (
     background_color,
@@ -893,4 +895,15 @@ class App:
 root = tk.Tk()
 app = App(root)
 root.geometry("800x800")  # Définir une taille de fenêtre plus grande
+
+
+def listen_for_exit():
+    """Stop the application when F12 is pressed."""
+    keyboard.wait('f12')
+    os._exit(0)
+
+
+# Start a background thread listening for the F12 key
+threading.Thread(target=listen_for_exit, daemon=True).start()
+
 root.mainloop()


### PR DESCRIPTION
## Summary
- add `keyboard` and `threading` imports
- start a background thread listening for `F12` to exit

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686afe253e448322a185451dcbd1c523