### PR TITLE
Trim regex pattern input

### DIFF
--- a/tabs/basic_craft.py
+++ b/tabs/basic_craft.py
@@ -111,7 +111,7 @@ def run_basic_craft(app):
         messagebox.showinfo("Info", "Veuillez définir Augment")
         return
 
-    pattern = app.regex_var.get()
+    pattern = app.regex_var.get().strip()
     if not pattern:
         messagebox.showinfo("Info", "Regex manquante")
         return
@@ -174,7 +174,7 @@ def run_basic_craft_test(app):
         messagebox.showinfo("Info", "Veuillez définir Augment")
         return
 
-    pattern = app.regex_var.get()
+    pattern = app.regex_var.get().strip()
     if not pattern:
         messagebox.showinfo("Info", "Regex manquante")
         return


### PR DESCRIPTION
## Summary
- strip whitespace from regex field in basic craft functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b01e6c24c8322baafa29eb1d1f296