### PR TITLE
Add global F12 exit with pynput

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import pygetwindow as gw
 
 import pyautogui
 import pyperclip
+from pynput import keyboard
 
 from global_functions import (
     background_color,
@@ -893,4 +894,16 @@ class App:
 root = tk.Tk()
 app = App(root)
 root.geometry("800x800")  # Définir une taille de fenêtre plus grande
+
+
+def listen_for_exit(key):
+    """Stop the application when F12 is pressed."""
+    if key == keyboard.Key.f12:
+        os._exit(0)
+
+
+# Start a background thread listening for the F12 key
+listener = keyboard.Listener(on_press=listen_for_exit)
+listener.start()
+
 root.mainloop()


### PR DESCRIPTION
## Summary
- switch from `keyboard` module to `pynput` for listening
- use a background listener that exits the app when F12 is pressed from anywhere

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686afe253e448322a185451dcbd1c523